### PR TITLE
Make UserHeaderBlock `{3:}` optional

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/message/SwiftMessageReader.java
+++ b/src/main/java/com/qoomon/banking/swift/message/SwiftMessageReader.java
@@ -72,7 +72,7 @@ public class SwiftMessageReader {
                     }
                     case ApplicationHeaderBlock.BLOCK_ID_2: {
                         messageBuilderApplicationHeaderBlock = ApplicationHeaderBlock.of(currentBlock);
-                        nextValidBlockIdSet = ImmutableSet.of(UserHeaderBlock.BLOCK_ID_3);
+                        nextValidBlockIdSet = ImmutableSet.of(UserHeaderBlock.BLOCK_ID_3, TextBlock.BLOCK_ID_4);
                         break;
                     }
                     case UserHeaderBlock.BLOCK_ID_3: {

--- a/src/test/java/com/qoomon/banking/swift/message/SwiftMessageReaderTest.java
+++ b/src/test/java/com/qoomon/banking/swift/message/SwiftMessageReaderTest.java
@@ -67,6 +67,22 @@ public class SwiftMessageReaderTest {
         assertThat(messageList).hasSize(2);
     }
 
+    @Test
+    public void parse_SHOULD_read_message_without_optional_blocks() throws Exception {
+
+        // Given
+        String swiftMessageText = ""
+                + BLOCK_1_DUMMY_VALID + BLOCK_2_DUMMY_VALID
+                + BLOCK_4_DUMMY_EMPTY;
+
+        SwiftMessageReader classUnderTest = new SwiftMessageReader(new StringReader(swiftMessageText));
+
+        // When
+        List<SwiftMessage> messageList = TestUtils.collectUntilNull(classUnderTest::read);
+
+        // Then
+        assertThat(messageList).hasSize(1);
+    }
 
     @Test
     public void parse_WHEN_first_bracket_is_missing_THEN_throw_exception() throws Exception {


### PR DESCRIPTION
Fixes #76 

This may be a bit of a naive fix, but at least in my testing it's working.