### PR TITLE
Make MT942 `floorLimitIndicatorDebit` optional if `floorLimitIndicatorCredit` is present

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/bcsmessage/BCSMessageParser.java
+++ b/src/main/java/com/qoomon/banking/swift/bcsmessage/BCSMessageParser.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
  * http://www.kontopruef.de/mt940s.shtml
  * <p>
  * <b>Format</b> '[BankTransactionCode]?[fieldId][content]?[fieldId][content]...'
- * <p>
+ * </p>
  */
 public class BCSMessageParser {
 

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
@@ -110,9 +110,15 @@ public class MT942Page {
         Preconditions.checkArgument(dateTimeIndicator != null, "dateTimeIndicator can't be null");
         Preconditions.checkArgument(transactionGroupList != null, "transactionGroupList can't be null");
 
-        // ensure matching currency
-        CurrencyUnit statementCurrency = (floorLimitIndicatorDebit != null ? floorLimitIndicatorDebit : floorLimitIndicatorCredit).getAmount().getCurrencyUnit();
+        // ensure matching currencies
+        CurrencyUnit statementCurrency = floorLimitIndicatorDebit.getAmount().getCurrencyUnit();
         String statementFundsCode = statementCurrency.getCode().substring(2, 3);
+        
+        {
+            // check floorLimitIndicatorCredit currency
+            CurrencyUnit currency = floorLimitIndicatorCredit.getAmount().getCurrencyUnit();
+            Preconditions.checkArgument(currency.equals(statementCurrency), "floorLimitCreditCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
+        }
 
         if (floorLimitIndicatorCredit != null) {
             CurrencyUnit currency = floorLimitIndicatorCredit.getAmount().getCurrencyUnit();

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
@@ -108,24 +108,24 @@ public class MT942Page {
         CurrencyUnit statementCurrency = (floorLimitIndicatorDebit != null ? floorLimitIndicatorDebit : floorLimitIndicatorCredit).getAmount().getCurrencyUnit();
         String statementFundsCode = statementCurrency.getCode().substring(2, 3);
 
-        if (floorLimitIndicatorCredit != null) {
+        if(floorLimitIndicatorCredit != null){
             CurrencyUnit currency = floorLimitIndicatorCredit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "floorLimitCreditCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }
 
         for (TransactionGroup transactionGroup : transactionGroupList) {
-            if (transactionGroup.getStatementLine().getFundsCode().isPresent()) {
+            if (transactionGroup.getStatementLine().getFundsCode().isPresent()){
                 String fundsCode = transactionGroup.getStatementLine().getFundsCode().get();
                 Preconditions.checkArgument(fundsCode.equals(statementFundsCode), "statementLineFundsCode '" + fundsCode + "' does not match statement currency'" + statementCurrency + "'");
             }
         }
 
-        if (transactionSummaryDebit != null) {
+        if(transactionSummaryDebit != null){
             CurrencyUnit currency = transactionSummaryDebit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "transactionSummaryDebitCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }
 
-        if (transactionSummaryCredit != null) {
+        if(transactionSummaryCredit != null){
             CurrencyUnit currency = transactionSummaryCredit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "transactionSummaryCreditCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942Page.java
@@ -91,7 +91,7 @@ public class MT942Page {
         Preconditions.checkArgument(transactionReferenceNumber != null, "transactionReferenceNumber can't be null");
         Preconditions.checkArgument(accountIdentification != null, "accountIdentification can't be null");
         Preconditions.checkArgument(statementNumber != null, "statementNumber can't be null");
-        Preconditions.checkArgument(floorLimitIndicatorDebit != null, "floorLimitIndicatorDebit can't be null");
+        Preconditions.checkArgument(floorLimitIndicatorDebit != null || floorLimitIndicatorCredit != null, "floorLimitIndicator can't be null");
         if (floorLimitIndicatorDebit != null && floorLimitIndicatorDebit.getDebitCreditMark().isPresent()) {
             DebitCreditMark debitCreditMark = floorLimitIndicatorDebit.getDebitCreditMark().get();
             Preconditions.checkArgument(debitCreditMark == DebitCreditMark.DEBIT, "floorLimitIndicatorDebit type can't " + debitCreditMark);
@@ -105,27 +105,27 @@ public class MT942Page {
 
 
         // ensure matching currency
-        CurrencyUnit statementCurrency = floorLimitIndicatorDebit.getAmount().getCurrencyUnit();
+        CurrencyUnit statementCurrency = (floorLimitIndicatorDebit != null ? floorLimitIndicatorDebit : floorLimitIndicatorCredit).getAmount().getCurrencyUnit();
         String statementFundsCode = statementCurrency.getCode().substring(2, 3);
 
-        if(floorLimitIndicatorCredit != null){
+        if (floorLimitIndicatorCredit != null) {
             CurrencyUnit currency = floorLimitIndicatorCredit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "floorLimitCreditCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }
 
         for (TransactionGroup transactionGroup : transactionGroupList) {
-            if (transactionGroup.getStatementLine().getFundsCode().isPresent()){
+            if (transactionGroup.getStatementLine().getFundsCode().isPresent()) {
                 String fundsCode = transactionGroup.getStatementLine().getFundsCode().get();
                 Preconditions.checkArgument(fundsCode.equals(statementFundsCode), "statementLineFundsCode '" + fundsCode + "' does not match statement currency'" + statementCurrency + "'");
             }
         }
 
-        if(transactionSummaryDebit != null){
+        if (transactionSummaryDebit != null) {
             CurrencyUnit currency = transactionSummaryDebit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "transactionSummaryDebitCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }
 
-        if(transactionSummaryCredit != null){
+        if (transactionSummaryCredit != null) {
             CurrencyUnit currency = transactionSummaryCredit.getAmount().getCurrencyUnit();
             Preconditions.checkArgument(currency.equals(statementCurrency), "transactionSummaryCreditCurrency '" + currency + "' does not match statement currency'" + statementCurrency + "'");
         }

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReader.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReader.java
@@ -6,6 +6,7 @@ import com.qoomon.banking.swift.message.exception.SwiftMessageParseException;
 import com.qoomon.banking.swift.submessage.PageSeparator;
 import com.qoomon.banking.swift.submessage.exception.PageParserException;
 import com.qoomon.banking.swift.submessage.field.*;
+import com.qoomon.banking.swift.submessage.field.subfield.DebitCreditMark;
 
 import java.io.Reader;
 import java.util.LinkedList;
@@ -96,13 +97,15 @@ public class MT942PageReader {
                         break;
                     }
                     case FloorLimitIndicator.FIELD_TAG_34F: {
-                        if (floorLimitIndicatorDebit == null) {
-                            floorLimitIndicatorDebit = FloorLimitIndicator.of(currentField);
+                        FloorLimitIndicator floorLimitIndicator = FloorLimitIndicator.of(currentField);
+                        if (!floorLimitIndicator.getDebitCreditMark().isPresent()
+                                || floorLimitIndicator.getDebitCreditMark().get() == DebitCreditMark.DEBIT) {
+                            floorLimitIndicatorDebit = floorLimitIndicator;
                             nextValidFieldSet = ImmutableSet.of(
                                     FloorLimitIndicator.FIELD_TAG_34F,
                                     DateTimeIndicator.FIELD_TAG_13D);
                         } else {
-                            floorLimitIndicatorCredit = FloorLimitIndicator.of(currentField);
+                            floorLimitIndicatorCredit = floorLimitIndicator;
                             nextValidFieldSet = ImmutableSet.of(DateTimeIndicator.FIELD_TAG_13D);
                         }
                         break;

--- a/src/test/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReaderTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReaderTest.java
@@ -5,12 +5,16 @@ import com.google.common.base.Throwables;
 import com.google.common.io.Resources;
 import com.qoomon.banking.TestUtils;
 import com.qoomon.banking.swift.message.exception.SwiftMessageParseException;
-import com.qoomon.banking.swift.submessage.mt940.MT940Page;
+import com.qoomon.banking.swift.submessage.field.FloorLimitIndicator;
+import com.qoomon.banking.swift.submessage.field.subfield.DebitCreditMark;
 import com.qoomon.banking.swift.submessage.mt940.MT940PageReader;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
 import org.junit.Test;
 
 import java.io.FileReader;
 import java.io.StringReader;
+import java.math.BigDecimal;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +33,6 @@ public class MT942PageReaderTest {
     public void parse_WHEN_parse_valid_file_RETURN_message() throws Exception {
 
         // Given
-
         String mt942MessageText = "" +
                 ":20:02761\n" +
                 ":25:6-9412771\n" +
@@ -59,6 +62,46 @@ public class MT942PageReaderTest {
         assertThat(MT942Page.getTransactionGroupList()).hasSize(3);
         assertThat(MT942Page.getStatementNumber().getStatementNumber()).isEqualTo("1");
         assertThat(MT942Page.getStatementNumber().getSequenceNumber()).contains("1");
+    }
+
+    @Test
+    public void parse_WHEN_parse_file_with_credit_floor_RETURN_message() throws Exception {
+
+        // Given
+        String mt942MessageText = "" +
+                ":20:02761\n" +
+                ":25:6-9412771\n" +
+                ":28C:1/1\n" +
+                ":34F:USDC123,\n" +
+                ":13D:0001032359+0500\n" +
+                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
+                ":86:multiline info\n" +
+                "-info\n" +
+                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
+                ":86:singleline info\n" +
+                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
+                ":90D:75475USD123,\n" +
+                ":90C:75475USD123,\n" +
+                ":86:multiline summary\n" +
+                "summary\n" +
+                "-";
+
+        MT942PageReader classUnderTest = new MT942PageReader(new StringReader(mt942MessageText));
+
+        // When
+        List<MT942Page> pageList = TestUtils.collectUntilNull(classUnderTest::read);
+
+        // Then
+        assertThat(pageList).hasSize(1);
+        MT942Page MT942Page = pageList.get(0);
+        assertThat(MT942Page.getTransactionGroupList()).hasSize(3);
+        assertThat(MT942Page.getStatementNumber().getStatementNumber()).isEqualTo("1");
+        assertThat(MT942Page.getStatementNumber().getSequenceNumber()).contains("1");
+        assertThat(MT942Page.getFloorLimitIndicatorDebit()).isNull();
+
+        FloorLimitIndicator creditFloorLimitIndicator = MT942Page.getFloorLimitIndicatorCredit();
+        assertThat(creditFloorLimitIndicator.getDebitCreditMark().orElse(null)).isEqualTo(DebitCreditMark.CREDIT);
+        assertThat(creditFloorLimitIndicator.getAmount()).isEqualTo(BigMoney.of(CurrencyUnit.USD, new BigDecimal("123")));
     }
 
     @Test

--- a/src/test/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReaderTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReaderTest.java
@@ -69,46 +69,6 @@ public class MT942PageReaderTest {
     }
 
     @Test
-    public void parse_WHEN_parse_file_with_credit_floor_RETURN_message() throws Exception {
-
-        // Given
-        String mt942MessageText = "" +
-                ":20:02761\n" +
-                ":25:6-9412771\n" +
-                ":28C:1/1\n" +
-                ":34F:USDC123,\n" +
-                ":13D:0001032359+0500\n" +
-                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
-                ":86:multiline info\n" +
-                "-info\n" +
-                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
-                ":86:singleline info\n" +
-                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
-                ":90D:75475USD123,\n" +
-                ":90C:75475USD123,\n" +
-                ":86:multiline summary\n" +
-                "summary\n" +
-                "-";
-
-        MT942PageReader classUnderTest = new MT942PageReader(new StringReader(mt942MessageText));
-
-        // When
-        List<MT942Page> pageList = TestUtils.collectUntilNull(classUnderTest::read);
-
-        // Then
-        assertThat(pageList).hasSize(1);
-        MT942Page MT942Page = pageList.get(0);
-        assertThat(MT942Page.getTransactionGroupList()).hasSize(3);
-        assertThat(MT942Page.getStatementNumber().getStatementNumber()).isEqualTo("1");
-        assertThat(MT942Page.getStatementNumber().getSequenceNumber()).contains("1");
-        assertThat(MT942Page.getFloorLimitIndicatorDebit()).isNull();
-
-        FloorLimitIndicator creditFloorLimitIndicator = MT942Page.getFloorLimitIndicatorCredit();
-        assertThat(creditFloorLimitIndicator.getDebitCreditMark().orElse(null)).isEqualTo(DebitCreditMark.CREDIT);
-        assertThat(creditFloorLimitIndicator.getAmount()).isEqualTo(BigMoney.of(CurrencyUnit.USD, new BigDecimal("123")));
-    }
-
-    @Test
     public void getContent_SHOULD_return_input_text() throws Exception {
 
         // Given


### PR DESCRIPTION
This PR makes the `floorLimitIndicatorDebit` optional if `floorLimitIndicatorCredit` is present in a MT942 message.

@qoomon I was unable to clarify what exactly the specification says about this, but it reflects a use case I am currently dealing with. Is this PR appropriate?