### PR TITLE
Fix StackOverflowError in long Text Block by using non-capturing Atomic Group

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/message/block/TextBlock.java
+++ b/src/main/java/com/qoomon/banking/swift/message/block/TextBlock.java
@@ -11,7 +11,7 @@ public class TextBlock implements SwiftBlock {
 
     public static final String BLOCK_ID_4 = "4";
 
-    public static final Pattern FIELD_PATTERN = Pattern.compile("([^\\n]+)?\\n((:?.*\\n)*-)");
+    public static final Pattern FIELD_PATTERN = Pattern.compile("([^\\n]+)?\\n((?>:?.*\\n)*-)");
 
     private final Optional<String> infoLine;
 


### PR DESCRIPTION
Fix StackOverflowError in very long Text Blocks by using non-capturing Atomic Group for inner group. The rest of the code only uses the first (info line) and second (outer text) groups. The repeating inner group is not used and is therefore replaced with a non-capturing group. This may also speed up parsing and reduce the memory footprint.