### PR TITLE
Introduce EntryDateResolutionStrategy

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy.java
@@ -1,0 +1,14 @@
+package com.qoomon.banking.swift.submessage.field.subfield;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+
+public class EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy implements EntryDateResolutionStrategy {
+    @Override
+    public LocalDate resolve(MonthDay entryMonthDay, LocalDate valueDate) {
+        int entryYear = entryMonthDay.getMonthValue() >= valueDate.getMonthValue()
+                ? valueDate.getYear()
+                : valueDate.getYear() + 1;
+        return entryMonthDay.atYear(entryYear);
+    }
+}

--- a/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/EntryDateResolutionStrategy.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/EntryDateResolutionStrategy.java
@@ -1,0 +1,18 @@
+package com.qoomon.banking.swift.submessage.field.subfield;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+
+/**
+ * Strategy to determine the correct {@link com.qoomon.banking.swift.submessage.field.StatementLine} entry date.
+ *
+ * Statement line :61: sub field 2 contains an optional entry date:
+ *
+ * Notation: [4!n]
+ * Format: 'MMDD'
+ *
+ * Implementers of this strategy must determine the correct year of the entry date based on the the given value date.
+ */
+public interface EntryDateResolutionStrategy {
+    LocalDate resolve(MonthDay entryMonthDay, LocalDate valueDate);
+}

--- a/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/ShortestDeltaEntryDateResolutionStrategy.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/field/subfield/ShortestDeltaEntryDateResolutionStrategy.java
@@ -1,0 +1,47 @@
+package com.qoomon.banking.swift.submessage.field.subfield;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
+
+/**
+ * Resolve entry date based on the shortest delta between the entry date and the value date.
+ * <p>
+ * This strategy views the {@link MonthDay} timeline as a circle, like the hours on a clock. If the shortest delta
+ * around the circle does not span 31 December, the entry date's year is the same as that of the value date. Otherwise
+ * it is either the previous year if the entry date is before the value date on the circular timeline, or the next year
+ * if the entry date is after the value date.
+ * <p>
+ * Limitations: This strategy can not account for an entry date more than 12 months in the past (or future).
+ */
+public class ShortestDeltaEntryDateResolutionStrategy implements EntryDateResolutionStrategy {
+    @Override
+    public LocalDate resolve(MonthDay entryMonthDay, LocalDate valueDate) {
+        int e = LocalDate.from(entryMonthDay.adjustInto(valueDate)).getDayOfYear();
+        int v = valueDate.getDayOfYear();
+        int lengthOfYear = valueDate.lengthOfYear();
+
+        int valueToEntryDelta = v - e;
+        boolean valueAfterEntry = valueToEntryDelta > 0;
+        int shortestDelta = min(abs(valueToEntryDelta), lengthOfYear - abs(valueToEntryDelta));
+
+        boolean spans31December = valueAfterEntry ?
+                e + shortestDelta != v :
+                v + shortestDelta != e;
+
+        int entryYear;
+        if (!spans31December) {
+            entryYear = valueDate.getYear();
+        } else {
+            if (valueAfterEntry) {
+                entryYear = valueDate.getYear() + 1;
+            } else {
+                entryYear = valueDate.getYear() - 1;
+            }
+        }
+
+        return entryMonthDay.atYear(entryYear);
+    }
+}

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt940/MT940PageReader.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt940/MT940PageReader.java
@@ -7,6 +7,8 @@ import com.qoomon.banking.swift.submessage.PageReader;
 import com.qoomon.banking.swift.submessage.PageSeparator;
 import com.qoomon.banking.swift.submessage.exception.PageParserException;
 import com.qoomon.banking.swift.submessage.field.*;
+import com.qoomon.banking.swift.submessage.field.subfield.EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy;
+import com.qoomon.banking.swift.submessage.field.subfield.EntryDateResolutionStrategy;
 
 import java.io.Reader;
 import java.util.LinkedList;
@@ -19,13 +21,19 @@ import java.util.Set;
 public class MT940PageReader extends PageReader<MT940Page> {
 
     private final SwiftFieldReader fieldReader;
+    private final EntryDateResolutionStrategy entryDateResolutionStrategy;
 
 
     public MT940PageReader(Reader textReader) {
+        this(textReader, new EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy());
+    }
+
+    public MT940PageReader(Reader textReader, EntryDateResolutionStrategy entryDateResolutionStrategy) {
 
         Preconditions.checkArgument(textReader != null, "textReader can't be null");
 
         this.fieldReader = new SwiftFieldReader(textReader);
+        this.entryDateResolutionStrategy = entryDateResolutionStrategy;
     }
 
     @Override
@@ -94,7 +102,7 @@ public class MT940PageReader extends PageReader<MT940Page> {
                         break;
                     }
                     case StatementLine.FIELD_TAG_61: {
-                        StatementLine statementLine = StatementLine.of(currentField);
+                        StatementLine statementLine = StatementLine.of(currentField, entryDateResolutionStrategy);
                         transactionList.add(new TransactionGroup(statementLine, null));
                         nextValidFieldSet = ImmutableSet.of(
                                 InformationToAccountOwner.FIELD_TAG_86,

--- a/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReader.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/mt942/MT942PageReader.java
@@ -8,6 +8,8 @@ import com.qoomon.banking.swift.submessage.PageSeparator;
 import com.qoomon.banking.swift.submessage.exception.PageParserException;
 import com.qoomon.banking.swift.submessage.field.*;
 import com.qoomon.banking.swift.submessage.field.subfield.DebitCreditMark;
+import com.qoomon.banking.swift.submessage.field.subfield.EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy;
+import com.qoomon.banking.swift.submessage.field.subfield.EntryDateResolutionStrategy;
 import org.joda.money.BigMoney;
 import org.joda.money.CurrencyUnit;
 
@@ -25,13 +27,19 @@ import static com.qoomon.banking.swift.submessage.field.subfield.DebitCreditMark
 public class MT942PageReader extends PageReader<MT942Page> {
 
     private final SwiftFieldReader fieldReader;
+    private final EntryDateResolutionStrategy entryDateResolutionStrategy;
 
 
     public MT942PageReader(Reader textReader) {
+        this(textReader, new EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy());
+    }
+
+    public MT942PageReader(Reader textReader, EntryDateResolutionStrategy entryDateResolutionStrategy) {
 
         Preconditions.checkArgument(textReader != null, "textReader can't be null");
 
         this.fieldReader = new SwiftFieldReader(textReader);
+        this.entryDateResolutionStrategy = entryDateResolutionStrategy;
     }
 
     @Override
@@ -149,7 +157,7 @@ public class MT942PageReader extends PageReader<MT942Page> {
                         break;
                     }
                     case StatementLine.FIELD_TAG_61: {
-                        StatementLine statementLine = StatementLine.of(currentField);
+                        StatementLine statementLine = StatementLine.of(currentField, entryDateResolutionStrategy);
                         transactionList.add(new TransactionGroup(statementLine, null));
                         nextValidFieldSet = ImmutableSet.of(
                                 StatementLine.FIELD_TAG_61,

--- a/src/test/java/com/qoomon/banking/swift/submessage/field/StatementLineTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/field/StatementLineTest.java
@@ -2,6 +2,7 @@ package com.qoomon.banking.swift.submessage.field;
 
 import com.qoomon.banking.swift.submessage.field.subfield.DebitCreditMark;
 import com.qoomon.banking.swift.submessage.field.subfield.DebitCreditType;
+import com.qoomon.banking.swift.submessage.field.subfield.EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy;
 import com.qoomon.banking.swift.submessage.field.subfield.TransactionTypeIdentificationCode;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -22,7 +23,7 @@ public class StatementLineTest {
         GeneralField generalField = new GeneralField(StatementLine.FIELD_TAG_61, "160130" + "C" + "R" + "123,456" + "NSTO" + "abcdef" + "//xyz" + "\nfoobar");
 
         // When
-        StatementLine field = StatementLine.of(generalField);
+        StatementLine field = StatementLine.of(generalField, new EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy());
 
         // Then
         assertThat(field.getTag()).isEqualTo(generalField.getTag());

--- a/src/test/java/com/qoomon/banking/swift/submessage/field/subfield/ShortestDeltaEntryDateResolutionStrategyTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/field/subfield/ShortestDeltaEntryDateResolutionStrategyTest.java
@@ -1,0 +1,48 @@
+package com.qoomon.banking.swift.submessage.field.subfield;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ShortestDeltaEntryDateResolutionStrategyTest {
+    private final EntryDateResolutionStrategy strategy = new ShortestDeltaEntryDateResolutionStrategy();
+
+    @Test
+    public void of_WHEN_smallest_delta_between_entry_date_and_value_date_does_not_span_December_THEN_entry_year_is_same_as_value_year() {
+        // When
+        LocalDate entryDate = strategy.resolve(MonthDay.parse("--05-12"), LocalDate.parse("2016-03-31"));
+
+        // Then
+        assertThat(entryDate).isEqualTo(LocalDate.parse("2016-05-12"));
+    }
+
+    @Test
+    public void of_WHEN_smallest_delta_does_not_span_December_and_entry_date_before_value_date_THEN_entry_year_is_same_as_value_year() {
+        // When
+        LocalDate entryDate = strategy.resolve(MonthDay.parse("--03-12"), LocalDate.parse("2016-05-31"));
+
+        // Then
+        assertThat(entryDate).isEqualTo(LocalDate.parse("2016-03-12"));
+    }
+
+    @Test
+    public void of_WHEN_smallest_delta_spans_December_and_entry_date_before_value_date_THEN_entry_year_is_next_year() {
+        // When
+        LocalDate entryDate = strategy.resolve(MonthDay.parse("--01-12"), LocalDate.parse("2015-10-31"));
+
+        // Then
+        assertThat(entryDate).isEqualTo(LocalDate.parse("2016-01-12"));
+    }
+
+    @Test
+    public void of_WHEN_smallest_delta_spans_December_and_entry_date_after_value_date_THEN_entry_year_is_previous_year() {
+        // When
+        LocalDate entryDate = strategy.resolve(MonthDay.parse("--11-12"), LocalDate.parse("2016-03-31"));
+
+        // Then
+        assertThat(entryDate).isEqualTo(LocalDate.parse("2015-11-12"));
+    }
+}


### PR DESCRIPTION
Currently this library resolves the year of a statement line entry date according to the rule that if the entry date month is before the value date month the year is the following year:
```java
// calculate entry year
int entryYear = entryMonthDay.getMonthValue() >= valueDate.getMonthValue()
       ? valueDate.getYear()
       : valueDate.getYear() + 1;
```

That rule works well if the entry date is always after the value date. However, if the value date is after the entry (as may be frequently the case) it yields unexpected results. For example, if the entry date is `--07-29` and the value date is `2020-08-01` the rule yields an entry date of `2021-07-29`.

This PR introduces the `EntryDateResolutionStrategy`. Users of `MT940PageReader` and `MT942PageReader` may now supply an `EntryDateResolutionStrategy` to define how statement line entry dates are resolved, based on the value date.

To maintain backwards compatibility the ability to supply the strategy is introduced through method overloads. Because users of the library may rely on the existing behaviour the default strategy is the `EarlierMonthImpliesFollowingYearEntryDateResolutionStrategy` which implements the exiting strategy, discussed above.

A `ShortestDeltaEntryDateResolutionStrategy` is also provided. This strategy views the `MonthDay` timeline as a circle, like the hours on a clock. If the shortest delta around the circle does not span 31 December, the entry date's year is the same as that of the value date. Otherwise it is either the previous year if the entry date is before the value date on the circular timeline, or the next year if the entry date is after the value date. This strategy may be most suitable if statements are delivered more frequently.

Unfortunately there is no perfect strategy for determining the correct year of the entry date. For a discussion on possible approaches, please see this thread: https://github.com/WoLpH/mt940/issues/17

### Example usage:
```java
MT942PageReader reader = new MT942PageReader(new StringReader(msg.textBlock.text), new ShortestDeltaEntryDateResolutionStrategy());
```