### PR TITLE
Fix StackOverflowError in extra-long Text Block by using the possessive quantifier to avoid backtracking

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/message/block/TextBlock.java
+++ b/src/main/java/com/qoomon/banking/swift/message/block/TextBlock.java
@@ -11,7 +11,7 @@ public class TextBlock implements SwiftBlock {
 
     public static final String BLOCK_ID_4 = "4";
 
-    public static final Pattern FIELD_PATTERN = Pattern.compile("([^\\n]+)?\\n((?>:?.*\\n)*-)");
+    public static final Pattern FIELD_PATTERN = Pattern.compile("([^\\n]+)?\\n((?>:?.*\\n)*+-)");
 
     private final Optional<String> infoLine;
 

--- a/src/test/java/com/qoomon/banking/swift/message/block/TextBlockTest.java
+++ b/src/test/java/com/qoomon/banking/swift/message/block/TextBlockTest.java
@@ -12,6 +12,21 @@ import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 public class TextBlockTest {
 
     @Test
+    public void of_WHEN_valid_block_with_info_line_is_passed_RETURN_new_block() throws Exception {
+
+        // Given
+        GeneralBlock generalBlock = new GeneralBlock(TextBlock.BLOCK_ID_4, "info\nabc\n-");
+
+        // When
+        TextBlock block = TextBlock.of(generalBlock);
+
+        // Then
+        assertThat(block).isNotNull();
+        assertThat(block.getInfoLine()).hasValue("info");
+        assertThat(block.getText()).isEqualTo("abc\n-");
+    }
+
+    @Test
     public void of_WHEN_valid_block_is_passed_RETURN_new_block() throws Exception {
 
         // Given


### PR DESCRIPTION
Possessive quantifiers are a way to prevent the regex engine from trying all permutations. Because it is impossible that there can be another match with a `-` at the end of the input (it's all or nothing), it is pointless backtracking to find other possible matches.

See https://www.regular-expressions.info/possessive.html