### PR TITLE
Fix/description line can start with colon

### DIFF
--- a/src/main/java/com/qoomon/banking/swift/submessage/field/SwiftFieldReader.java
+++ b/src/main/java/com/qoomon/banking/swift/submessage/field/SwiftFieldReader.java
@@ -91,7 +91,7 @@ public class SwiftFieldReader {
                     contentBuilder.toString()
             );
         } catch (FieldParseException e) {
-                throw e;
+            throw e;
         } catch (Exception e) {
             throw new FieldParseException(e.getMessage(), getFieldLineNumber(), e);
         }
@@ -111,7 +111,10 @@ public class SwiftFieldReader {
             return FieldLineType.SEPARATOR;
         }
         if (messageLine.startsWith(":")) {
-            return FieldLineType.FIELD;
+            Matcher tagMatcher = FIELD_STRUCTURE_PATTERN.matcher(messageLine);
+            if (tagMatcher.matches() && tagMatcher.group("tag") != null) {
+                return FieldLineType.FIELD;
+            }
         }
         return FieldLineType.FIELD_CONTINUATION;
 

--- a/src/test/java/com/qoomon/banking/swift/submessage/field/StatementLineTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/field/StatementLineTest.java
@@ -28,8 +28,8 @@ public class StatementLineTest {
         assertThat(field.getTag()).isEqualTo(generalField.getTag());
         assertThat(field.getContent()).isEqualTo(generalField.getContent());
         assertThat(field.getDebitCreditType()).isEqualTo(DebitCreditType.REGULAR);
+        assertThat(field.getSignedAmount()).isEqualTo(new BigDecimal("123.456"));
     }
-
 
     @Test
     public void getSignedAmount_WHEN_regular_debit_transaction_THEN_return_negative_amount() throws Exception {

--- a/src/test/java/com/qoomon/banking/swift/submessage/mt940/MT940PageReaderTest.java
+++ b/src/test/java/com/qoomon/banking/swift/submessage/mt940/MT940PageReaderTest.java
@@ -35,6 +35,7 @@ public class MT940PageReaderTest {
                 ":28C:00102\n" +
                 ":60F:C000103USD672,\n" +
                 ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
+                "supplementary info\n" +
                 ":86:multiline info\n" +
                 "-info\n" +
                 ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
@@ -56,6 +57,29 @@ public class MT940PageReaderTest {
         SoftAssertions softly = new SoftAssertions();
         softly.assertThat(MT940Page.getTransactionGroupList()).hasSize(3);
         softly.assertThat(MT940Page.getTransactionGroupList()).hasSize(3);
+    }
+
+    @Test
+    public void parse_WHEN_supplementary_details_start_with_colon_THEN_it_is_correctly_parsed() throws Exception {
+
+        // Given
+        String mt940MessageText = ":20:02618\n" +
+                ":21:123456/DEV\n" +
+                ":25:6-9412771\n" +
+                ":28C:00102\n" +
+                ":60F:C000103USD672,\n" +
+                ":61:0312091211D880,FTRFBPHP/081203/0003//59512112915002\n" +
+                ":colon is valid x char set\n" +
+                ":62F:C000103USD987,\n" +
+                "-";
+
+        MT940PageReader classUnderTest = new MT940PageReader(new StringReader(mt940MessageText));
+
+        // When
+        List<MT940Page> pageList = TestUtils.collectUntilNull(classUnderTest::read);
+
+        // Then
+        assertThat(pageList).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
Currently the parser can not handle supplementary details if the line starts with a colon (`:`) and will fail, even though the colon is a part of the SWIFT X-character set. For example, this statement line can not be parsed:

```
:61:2201070107CR1000,15NDEP: my reference//NONREF
: my reference for payment
```

This change will only recognize a line starting with a colon as a new field if it starts with a fully-formed tag, with a opening and a closing colon, as well as the tag ID.